### PR TITLE
refactor(CacheRemovingBehavior) - CacheGroupKey variable converted to array

### DIFF
--- a/Core.Application/Pipelines/Caching/CacheRemovingBehavior.cs
+++ b/Core.Application/Pipelines/Caching/CacheRemovingBehavior.cs
@@ -27,20 +27,23 @@ public class CacheRemovingBehavior<TRequest, TResponse> : IPipelineBehavior<TReq
 
         if (request.CacheGroupKey != null)
         {
-            byte[]? cachedGroup = await _cache.GetAsync(request.CacheGroupKey, cancellationToken);
-            if (cachedGroup != null)
+            for (int i = 0; i < request.CacheGroupKey.Count(); i++)
             {
-                HashSet<string> keysInGroup = JsonSerializer.Deserialize<HashSet<string>>(Encoding.Default.GetString(cachedGroup))!;
-                foreach (string key in keysInGroup)
+                byte[]? cachedGroup = await _cache.GetAsync(request.CacheGroupKey[i], cancellationToken);
+                if (cachedGroup != null)
                 {
-                    await _cache.RemoveAsync(key, cancellationToken);
-                    _logger.LogInformation($"Removed Cache -> {key}");
-                }
+                    HashSet<string> keysInGroup = JsonSerializer.Deserialize<HashSet<string>>(Encoding.Default.GetString(cachedGroup))!;
+                    foreach (string key in keysInGroup)
+                    {
+                        await _cache.RemoveAsync(key, cancellationToken);
+                        _logger.LogInformation($"Removed Cache -> {key}");
+                    }
 
-                await _cache.RemoveAsync(request.CacheGroupKey, cancellationToken);
-                _logger.LogInformation($"Removed Cache -> {request.CacheGroupKey}");
-                await _cache.RemoveAsync(key: $"{request.CacheGroupKey}SlidingExpiration", cancellationToken);
-                _logger.LogInformation($"Removed Cache -> {request.CacheGroupKey}SlidingExpiration");
+                    await _cache.RemoveAsync(request.CacheGroupKey[i], cancellationToken);
+                    _logger.LogInformation($"Removed Cache -> {request.CacheGroupKey}");
+                    await _cache.RemoveAsync(key: $"{request.CacheGroupKey}SlidingExpiration", cancellationToken);
+                    _logger.LogInformation($"Removed Cache -> {request.CacheGroupKey}SlidingExpiration");
+                }
             }
         }
 

--- a/Core.Application/Pipelines/Caching/ICacheRemoverRequest.cs
+++ b/Core.Application/Pipelines/Caching/ICacheRemoverRequest.cs
@@ -4,5 +4,5 @@ public interface ICacheRemoverRequest
 {
     bool BypassCache { get; }
     string? CacheKey { get; }
-    string? CacheGroupKey { get; }
+    string[]? CacheGroupKey { get; }
 }


### PR DESCRIPTION
Örneğin: Model tablosuna eklenen bir Brand için güncelleme işlemi yaptığımızda model tablosunda ön bellek temizlenmediği için brand tablosunda değişiklik yapılan veri Model tablosunda değişmeme sorunu oluşuyordu. Bu sebepten dolayı cachGroupKey dizi türüne çevrildi.